### PR TITLE
chore: Node 24-ready action bumps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,10 +43,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
GitHub is force-migrating Node 20 JavaScript actions to Node 24 on **June 16, 2026** (deprecation warnings already showing in CI logs). This bumps the workflow action pins in this repo to their current Node 24-ready major versions.

## Bumps
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`
- `actions/configure-pages@v4` -> `actions/configure-pages@v6`
- `actions/deploy-pages@v4` -> `actions/deploy-pages@v5`
- `actions/upload-pages-artifact@v3` -> `actions/upload-pages-artifact@v5`

Each target major was verified Node 24-ready via `runs.using: node24` in the action's `action.yml` at its latest release tag. Version pins only — no other workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
